### PR TITLE
feat: Add CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,29 @@ try {
 }
 ```
 
+## CLI Usage
+
+Transformatron can be used directly on the CLI:
+
+```sh
+$ bin/transformatron path/to/spdx.json
+{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    ...
+```
+
+The CLI tool supports the ability to automatically detect source and target versions, but they can also be specified manually:
+
+```
+Usage: transformatron <path-to-sbom-file> [--format=spdx|cyclonedx] [--target=spdx|cyclonedx]
+Options:
+    --format=spdx|cyclonedx  Specify the format of the input SBOM file
+    --target=spdx|cyclonedx  Specify the format of the output SBOM file
+    --help                   Display this help message
+    --version                Display the version of this tool
+```
+
 ## Advanced Usage
 
 ### Auto-detecting Format

--- a/bin/transformatron
+++ b/bin/transformatron
@@ -1,0 +1,96 @@
+#!/usr/bin/env php
+<?php
+use SBOMinator\Transformatron\Converter;
+use SBOMinator\Transformatron\Exception\ConversionException;
+use SBOMinator\Transformatron\Exception\ValidationException;
+
+const USAGE = <<<'END'
+	Usage: transformatron <path-to-sbom-file> [--format=spdx|cyclonedx] [--target=spdx|cyclonedx]
+	Options:
+		--format=spdx|cyclonedx  Specify the format of the input SBOM file
+		--target=spdx|cyclonedx  Specify the format of the output SBOM file
+		--help                   Display this help message
+		--version                Display the version of this tool
+	END;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$cmd = array_shift($argv);
+$format = 'auto';
+$target = 'auto';
+$path = null;
+foreach ($argv as $arg) {
+	switch (true) {
+		case ($arg === '--version' || $arg === '-v'):
+			echo "Transformatron version 1.0.0\n";
+			exit(0);
+
+		case $arg === '--help' || $arg === '-h':
+			echo USAGE;
+			exit(0);
+
+		case str_starts_with($arg, '--format='):
+			$format = substr($arg, 9);
+			if ($format !== 'spdx' && $format !== 'cyclonedx') {
+				echo "Error: Invalid format specified\n";
+				exit(1);
+			}
+			$format = $format === 'spdx' ? Converter::FORMAT_SPDX : Converter::FORMAT_CYCLONEDX;
+			break;
+
+		case str_starts_with($arg, '--target='):
+			$target = substr($arg, 9);
+			if ($target !== 'spdx' && $target !== 'cyclonedx') {
+				echo "Error: Invalid target specified\n";
+				exit(1);
+			}
+			$target = $target === 'spdx' ? Converter::FORMAT_SPDX : Converter::FORMAT_CYCLONEDX;
+			break;
+
+		case '--' === $arg:
+			$path = array_shift($argv);
+			break 2;
+
+		case '-' === $arg:
+			$path = 'php://stdin';
+			break 2;
+
+		case str_starts_with($arg, '-'):
+			echo "Error: Invalid option: $arg\n";
+			exit(1);
+
+		default:
+			$path = $arg;
+			break 2;
+	}
+}
+
+if (empty($path)) {
+	echo USAGE;
+	exit(1);
+}
+
+// Read the JSON from the provided path
+$json = file_get_contents($path);
+
+// Detect the format
+$converter = new Converter();
+if ($format === 'auto') {
+	$format = $converter->detectFormat($json);
+	if (!$format) {
+		fprintf(STDERR, "Detected format: " . $format . "\n");
+	}
+}
+if ($target === 'auto') {
+	$target = $format === Converter::FORMAT_SPDX ? Converter::FORMAT_CYCLONEDX : Converter::FORMAT_SPDX;
+}
+
+// Convert to target format using auto-detection
+try {
+    // $targetFormat = Converter::FORMAT_CYCLONEDX; // or Converter::FORMAT_SPDX
+    $result = $converter->convert($json, $target, $format);
+	echo $result->getContent();
+} catch (ValidationException | ConversionException $e) {
+    fprintf(STDERR, "Error: " . $e->getMessage() . "\n");
+}
+

--- a/bin/transformatron
+++ b/bin/transformatron
@@ -4,8 +4,12 @@ use SBOMinator\Transformatron\Converter;
 use SBOMinator\Transformatron\Exception\ConversionException;
 use SBOMinator\Transformatron\Exception\ValidationException;
 
-const USAGE = <<<'END'
-	Usage: transformatron <path-to-sbom-file> [--format=spdx|cyclonedx] [--target=spdx|cyclonedx]
+require __DIR__ . '/../vendor/autoload.php';
+
+$cmd = array_shift($argv);
+
+$usage = <<<"END"
+	Usage: $cmd <path-to-sbom-file> [--format=spdx|cyclonedx] [--target=spdx|cyclonedx]
 	Options:
 		--format=spdx|cyclonedx  Specify the format of the input SBOM file
 		--target=spdx|cyclonedx  Specify the format of the output SBOM file
@@ -13,9 +17,6 @@ const USAGE = <<<'END'
 		--version                Display the version of this tool
 	END;
 
-require __DIR__ . '/../vendor/autoload.php';
-
-$cmd = array_shift($argv);
 $format = 'auto';
 $target = 'auto';
 $path = null;
@@ -26,7 +27,7 @@ foreach ($argv as $arg) {
 			exit(0);
 
 		case $arg === '--help' || $arg === '-h':
-			echo USAGE;
+			echo $usage;
 			exit(0);
 
 		case str_starts_with($arg, '--format='):
@@ -66,7 +67,7 @@ foreach ($argv as $arg) {
 }
 
 if (empty($path)) {
-	echo USAGE;
+	echo $usage;
 	exit(1);
 }
 
@@ -93,4 +94,3 @@ try {
 } catch (ValidationException | ConversionException $e) {
     fprintf(STDERR, "Error: " . $e->getMessage() . "\n");
 }
-

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     },
     "scripts": {
         "test": "phpunit"
-    }
+    },
+    "bin": [
+        "bin/transformatron"
+    ]
 }


### PR DESCRIPTION
This adds the ability to run transformatron directly via the CLI as a one-off command:

```
$ bin/transformatron path/to/spdx.json
{
    "bomFormat": "CycloneDX",
    "specVersion": "1.4",
    ...
```